### PR TITLE
Add defaults - calling file's namespace and relative src directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Alley_Interactive\Autoloader\Autoloader::generate(
 	null,
 	__DIR__ . '/src',
 )->register();
+
+// Omit the root path parameter to use 'src' directory relative to the calling file.
+spl_autoload_register(
+	Alley_Interactive\Autoloader\Autoloader::generate(
+		'Plugin\\Namespace'
+	)
+);
+
+// Pass no arguments to use the current file's name space and 'src' directory relative to the calling file.
+Alley_Interactive\Autoloader\Autoloader::generate()->register();
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ spl_autoload_register(
 		__DIR__ . '/src',
 	)
 );
+
+// Pass null as the namespace to use the current file's namespace.
+Alley_Interactive\Autoloader\Autoloader::generate(
+	null,
+	__DIR__ . '/src',
+)->register();
 ```
 
 ## Testing

--- a/src/class-autoloader.php
+++ b/src/class-autoloader.php
@@ -47,7 +47,7 @@ class Autoloader {
 	 * @param string $root_path Path in which to look for files.
 	 * @return static Function for spl_autoload_register().
 	 */
-	public static function generate( string $namespace, string $root_path ): callable {
+	public static function generate( ?string $namespace, string $root_path ): callable {
 		return new static( $namespace, $root_path );
 	}
 

--- a/src/class-autoloader.php
+++ b/src/class-autoloader.php
@@ -232,7 +232,6 @@ class Autoloader {
 
 		// [0] is the __construct function, [1] is who called it.
 		$calling_file = $debug_backtrace[1]['file'];
-
 		$calling_directory = dirname( $calling_file );
 
 		return $calling_directory;

--- a/src/class-autoloader.php
+++ b/src/class-autoloader.php
@@ -47,7 +47,7 @@ class Autoloader {
 	 * @param string $root_path Path in which to look for files.
 	 * @return static Function for spl_autoload_register().
 	 */
-	public static function generate( ?string $namespace, ?string $root_path ): callable {
+	public static function generate( ?string $namespace = null, ?string $root_path = null ): callable {
 		return new static( $namespace, $root_path );
 	}
 
@@ -57,7 +57,7 @@ class Autoloader {
 	 * @param string $namespace Namespace to register.
 	 * @param string $root_path Root path of the namespace.
 	 */
-	public function __construct( ?string $namespace, ?string $root_path ) {
+	public function __construct( ?string $namespace = null, ?string $root_path = null ) {
 		$this->namespace = $namespace ?? $this->get_calling_file_namespace();
 
 		$root_path = $root_path ?? __DIR__ . '/src';

--- a/src/class-autoloader.php
+++ b/src/class-autoloader.php
@@ -57,8 +57,8 @@ class Autoloader {
 	 * @param string $namespace Namespace to register.
 	 * @param string $root_path Root path of the namespace.
 	 */
-	public function __construct( string $namespace, string $root_path ) {
-		$this->namespace = $namespace;
+	public function __construct( ?string $namespace, string $root_path ) {
+		$this->namespace = $namespace ?? $this->get_calling_file_namespace();
 
 		// Ensure consistent root.
 		$this->root_path = rtrim( $root_path, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
@@ -199,5 +199,23 @@ class Autoloader {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get the namespace of the file that instantiated this class, presumably the root namespace.
+	 *
+	 * phpcs:disable WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+	 * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+	 * phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_fclose
+	 * phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_fopen
+	 */
+	public function get_calling_file_namespace() {
+
+		$debug_backtrace = debug_backtrace( DEBUG_BACKTRACE_PROVIDE_OBJECT || DEBUG_BACKTRACE_IGNORE_ARGS, 2 );
+
+		$class = new \ReflectionClass( $debug_backtrace[1]['class'] );
+		$calling_namespace = $class->getNamespaceName();
+
+		return $calling_namespace;
 	}
 }

--- a/src/class-autoloader.php
+++ b/src/class-autoloader.php
@@ -59,7 +59,6 @@ class Autoloader {
 	 */
 	public function __construct( ?string $namespace = null, ?string $root_path = null ) {
 		$this->namespace = $namespace ?? $this->get_calling_file_namespace();
-
 		$root_path = $root_path ?? $this->get_calling_directory() . '/src';
 
 		// Ensure consistent root.

--- a/src/class-autoloader.php
+++ b/src/class-autoloader.php
@@ -60,7 +60,7 @@ class Autoloader {
 	public function __construct( ?string $namespace = null, ?string $root_path = null ) {
 		$this->namespace = $namespace ?? $this->get_calling_file_namespace();
 
-		$root_path = $root_path ?? __DIR__ . '/src';
+		$root_path = $root_path ?? $this->get_calling_directory() . '/src';
 
 		// Ensure consistent root.
 		$this->root_path = rtrim( $root_path, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
@@ -219,5 +219,22 @@ class Autoloader {
 		$calling_namespace = $class->getNamespaceName();
 
 		return $calling_namespace;
+	}
+
+	/**
+	 * Get the directory of the file that instantiated this class.
+	 *
+	 * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+	 */
+	public function get_calling_directory() {
+
+		$debug_backtrace = debug_backtrace( DEBUG_BACKTRACE_PROVIDE_OBJECT || DEBUG_BACKTRACE_IGNORE_ARGS, 2 );
+
+		// [0] is the __construct function, [1] is who called it.
+		$calling_file = $debug_backtrace[1]['file'];
+
+		$calling_directory = dirname( $calling_file );
+
+		return $calling_directory;
 	}
 }

--- a/src/class-autoloader.php
+++ b/src/class-autoloader.php
@@ -47,7 +47,7 @@ class Autoloader {
 	 * @param string $root_path Path in which to look for files.
 	 * @return static Function for spl_autoload_register().
 	 */
-	public static function generate( ?string $namespace, string $root_path ): callable {
+	public static function generate( ?string $namespace, ?string $root_path ): callable {
 		return new static( $namespace, $root_path );
 	}
 
@@ -57,8 +57,10 @@ class Autoloader {
 	 * @param string $namespace Namespace to register.
 	 * @param string $root_path Root path of the namespace.
 	 */
-	public function __construct( ?string $namespace, string $root_path ) {
+	public function __construct( ?string $namespace, ?string $root_path ) {
 		$this->namespace = $namespace ?? $this->get_calling_file_namespace();
+
+		$root_path = $root_path ?? __DIR__ . '/src';
 
 		// Ensure consistent root.
 		$this->root_path = rtrim( $root_path, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;

--- a/tests/test-autoload.php
+++ b/tests/test-autoload.php
@@ -163,4 +163,20 @@ class Test_Autoload extends TestCase {
 			class_exists( __NAMESPACE__ . '\Autoloaded\Other_Autoloaded_Class' ),
 		);
 	}
+
+	/**
+	 * Test using backtrace to determine the namespace that should be used
+	 */
+	public function test_get_calling_file_namespace() {
+
+		$sut = new Autoloader( 'namespace', 'path' );
+
+		// $method = new \ReflectionMethod( Autoloader::class, 'get_calling_file_namespace' );
+		// $method->setAccessible( true );
+		//
+		// $result = $method->invoke( $sut );
+		$result = $sut->get_calling_file_namespace();
+
+		$this->assertEquals( __NAMESPACE__, $result );
+	}
 }

--- a/tests/test-autoload.php
+++ b/tests/test-autoload.php
@@ -171,10 +171,6 @@ class Test_Autoload extends TestCase {
 
 		$sut = new Autoloader( 'namespace', 'path' );
 
-		// $method = new \ReflectionMethod( Autoloader::class, 'get_calling_file_namespace' );
-		// $method->setAccessible( true );
-		//
-		// $result = $method->invoke( $sut );
 		$result = $sut->get_calling_file_namespace();
 
 		$this->assertEquals( __NAMESPACE__, $result );


### PR DESCRIPTION
The goal here is to allow:

```
Alley_Interactive\Autoloader\Autoloader::generate()->register();
```

by using the namespace of the calling file, and the `src` directory relative to that calling file as defaults.

Uses `debug_backtrace()` and reflection. Could be achieved without reflection, but the code is clearer this way.

No breaking changes.